### PR TITLE
Fix Travis build: install bower globally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,6 @@ addons:
   chrome: latest
 
 install:
+  - npm install -g bower
   - npm install
   - bower install
-


### PR DESCRIPTION
After the recent change, `package.json` no longer contains `bower` so we should install it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-core/204)
<!-- Reviewable:end -->
