### PR TITLE
fix: add missing vaadin-tabsheet and vaadin-tooltip imports (24.0)

### DIFF
--- a/vaadin-core.js
+++ b/vaadin-core.js
@@ -49,6 +49,7 @@ import '@vaadin/tabsheet';
 import '@vaadin/text-area';
 import '@vaadin/text-field';
 import '@vaadin/time-picker';
+import '@vaadin/tooltip';
 import '@vaadin/upload';
 import '@vaadin/vertical-layout';
 import '@vaadin/virtual-list';

--- a/vaadin-core.js
+++ b/vaadin-core.js
@@ -45,6 +45,7 @@ import '@vaadin/scroller';
 import '@vaadin/select';
 import '@vaadin/split-layout';
 import '@vaadin/tabs';
+import '@vaadin/tabsheet';
 import '@vaadin/text-area';
 import '@vaadin/text-field';
 import '@vaadin/time-picker';


### PR DESCRIPTION
## Description

Same as #279 but for `24.0` branch.

## Type of change

- Bugfix